### PR TITLE
Add security context to CronJob

### DIFF
--- a/config/watchdogs/watchdogs.yaml
+++ b/config/watchdogs/watchdogs.yaml
@@ -17,5 +17,11 @@ spec:
             image: k8s-watchdogs
             imagePullPolicy: IfNotPresent
             command: ["/watchdogs"]
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 65534
+              seccompProfile:
+                type: RuntimeDefault
+              readOnlyRootFilesystem: true
           restartPolicy: OnFailure
           activeDeadlineSeconds: 60


### PR DESCRIPTION
## Summary
- harden CronJob container runtime

## Testing
- `make vet`
- `go test ./...`
- `kubectl apply --dry-run=client` *(failed: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6876fc115eec832ab33e999ca406b3d9