### PR TITLE
Add security context inline for CronJob

### DIFF
--- a/config/watchdogs/watchdogs.yaml
+++ b/config/watchdogs/watchdogs.yaml
@@ -20,8 +20,7 @@ spec:
             securityContext:
               runAsNonRoot: true
               runAsUser: 65534
-              seccompProfile:
-                type: RuntimeDefault
+              seccompProfile: {type: RuntimeDefault}
               readOnlyRootFilesystem: true
           restartPolicy: OnFailure
           activeDeadlineSeconds: 60


### PR DESCRIPTION
## Summary
- inline seccompProfile configuration under the container securityContext

## Testing
- `make vet`
- `go test ./...`
- `kubectl apply --dry-run=client -f config/watchdogs/watchdogs.yaml` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687b94a93ce4832a8a8542793c8c979c