### PR TITLE
Update Go toolchain to 1.24.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS build
+FROM golang:1.24.4-alpine AS build
 
 ARG GITVERSION
 ARG MODULE_PACKAGE

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/norseto/k8s-watchdogs
 
 go 1.24.0
 
-toolchain go1.24.2
+toolchain go1.24.4
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
## Summary
- set Go toolchain to 1.24.4
- use `golang:1.24.4-alpine` for the builder image

## Testing
- `go fmt ./...`
- `make vet`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687cebae6064832a822ace37271ad0e0