### PR TITLE
add restart sts unit tests

### DIFF
--- a/internal/cmd/restart-sts/restart-sts_test.go
+++ b/internal/cmd/restart-sts/restart-sts_test.go
@@ -26,6 +26,8 @@ package restartsts
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,24 +41,117 @@ import (
 // Common context used in tests
 var testCtx = context.TODO()
 
-func TestRestartStatefulSet(t *testing.T) {
-	sts := &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-sts",
-			Namespace: "default",
-		},
+func TestValidateResourceName(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid", "valid-name", false},
+		{"with dot", "sts.app", false},
+		{"numeric", "abc123", false},
+		{"empty", "", true},
+		{"invalid char", "Invalid*", true},
+		{"too long", strings.Repeat("a", 254), true},
 	}
-	client := fake.NewSimpleClientset(sts)
 
-	var patchCalled bool
-	client.PrependReactor("patch", "statefulsets", func(action ktesting.Action) (bool, runtime.Object, error) {
-		patchCalled = true
-		return false, nil, nil
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateResourceName(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateNamespace(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"default", "default", false},
+		{"dash", "my-ns", false},
+		{"empty", "", true},
+		{"invalid char", "Invalid*", true},
+		{"too long", strings.Repeat("a", 64), true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateNamespace(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRestartStatefulSet(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sts",
+				Namespace: "default",
+			},
+		}
+		client := fake.NewSimpleClientset(sts)
+
+		var patchCalled bool
+		client.PrependReactor("patch", "statefulsets", func(action ktesting.Action) (bool, runtime.Object, error) {
+			patchCalled = true
+			return false, nil, nil
+		})
+
+		err := restartStatefulSet(testCtx, client, "default", []string{"test-sts"})
+		assert.NoError(t, err)
+		assert.True(t, patchCalled, "Expected patch to be called")
 	})
 
-	err := restartStatefulSet(testCtx, client, "default", []string{"test-sts"})
-	assert.NoError(t, err)
-	assert.True(t, patchCalled, "Expected patch to be called")
+	t.Run("too many targets", func(t *testing.T) {
+		var names []string
+		for i := 0; i < 51; i++ {
+			names = append(names, fmt.Sprintf("sts-%d", i))
+		}
+		client := fake.NewSimpleClientset()
+		err := restartStatefulSet(testCtx, client, "default", names)
+		assert.Error(t, err)
+	})
+
+	t.Run("get failure", func(t *testing.T) {
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sts",
+				Namespace: "default",
+			},
+		}
+		client := fake.NewSimpleClientset(sts)
+		client.PrependReactor("get", "statefulsets", func(action ktesting.Action) (bool, runtime.Object, error) {
+			return true, nil, assert.AnError
+		})
+		err := restartStatefulSet(testCtx, client, "default", []string{"test-sts"})
+		assert.Error(t, err)
+	})
+
+	t.Run("restart failure", func(t *testing.T) {
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sts",
+				Namespace: "default",
+			},
+		}
+		client := fake.NewSimpleClientset(sts)
+		client.PrependReactor("patch", "statefulsets", func(action ktesting.Action) (bool, runtime.Object, error) {
+			return true, nil, assert.AnError
+		})
+		err := restartStatefulSet(testCtx, client, "default", []string{"test-sts"})
+		assert.Error(t, err)
+	})
 }
 
 func TestNewCommand(t *testing.T) {
@@ -67,6 +162,21 @@ func TestNewCommand(t *testing.T) {
 	allFlag := cmd.Flag("all")
 	assert.NotNil(t, allFlag, "Expected --all flag to exist")
 	assert.Equal(t, "a", allFlag.Shorthand, "Expected shorthand for --all to be -a")
+
+	t.Run("invalid namespace", func(t *testing.T) {
+		cmd := NewCommand()
+		cmd.Flags().Set("namespace", "Invalid*")
+		cmd.SetArgs([]string{"test"})
+		err := cmd.Execute()
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid name", func(t *testing.T) {
+		cmd := NewCommand()
+		cmd.SetArgs([]string{"Invalid*"})
+		err := cmd.Execute()
+		assert.Error(t, err)
+	})
 }
 
 func TestRestartAllStatefulSets(t *testing.T) {
@@ -132,5 +242,20 @@ func TestRestartAllStatefulSets(t *testing.T) {
 		// Verify that both statefulsets were attempted to be patched
 		assert.True(t, patchCalls["statefulset-1"], "Expected statefulset-1 to be restarted")
 		assert.True(t, patchCalls["statefulset-2"], "Expected statefulset-2 to be attempted to be restarted")
+	})
+
+	t.Run("list fails", func(t *testing.T) {
+		failingClient := fake.NewSimpleClientset()
+		failingClient.PrependReactor("list", "statefulsets", func(action ktesting.Action) (bool, runtime.Object, error) {
+			return true, nil, assert.AnError
+		})
+		err := restartAllStatefulSets(ctx, failingClient, "default")
+		assert.Error(t, err)
+	})
+
+	t.Run("no statefulsets", func(t *testing.T) {
+		emptyClient := fake.NewSimpleClientset()
+		err := restartAllStatefulSets(ctx, emptyClient, "default")
+		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
## Summary
- expand table driven tests for restart-sts validations
- cover restartStatefulSet and restartAllStatefulSets error scenarios
- validate NewCommand argument handling

## Testing
- `make vet`
- `make test`
- `make seccheck`
- `make lint` *(fails: go1.23 < go1.24.4)*
- `make vulcheck` *(fails: go1.23 < go1.24)*

------
https://chatgpt.com/codex/tasks/task_e_688af2daddf0832ab57655bb9ee701ea