### PR TITLE
Add unsupported operator cases to node selector tests

### DIFF
--- a/pkg/kube/node_test.go
+++ b/pkg/kube/node_test.go
@@ -133,6 +133,30 @@ func TestNodeMatchesNodeSelector(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "GtOperatorReturnsFalse",
+			node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "5"}}},
+			selector: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+					MatchExpressions: []corev1.NodeSelectorRequirement{{
+						Key: "foo", Values: []string{"10"}, Operator: corev1.NodeSelectorOpGt,
+					}},
+				}},
+			},
+			expected: false,
+		},
+		{
+			name: "LtOperatorReturnsFalse",
+			node: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "5"}}},
+			selector: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+					MatchExpressions: []corev1.NodeSelectorRequirement{{
+						Key: "foo", Values: []string{"1"}, Operator: corev1.NodeSelectorOpLt,
+					}},
+				}},
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
## Summary
- cover unsupported Gt and Lt node selector operators in tests

## Testing
- `go fmt ./...`
- `make vet`
- `make lint` *(fails: the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24.6))*
- `make test`
- `make vulcheck` *(fails: packages require Go 1.24 but govulncheck built with go1.23)*
- `make seccheck`


------
https://chatgpt.com/codex/tasks/task_e_68aaa7ea8bd8832a9a9f7f89fd7bbdb7