### PR TITLE
Add invalid namespace test for cleanEvictedPods

### DIFF
--- a/internal/cmd/clean-evicted/clean-evicted_test.go
+++ b/internal/cmd/clean-evicted/clean-evicted_test.go
@@ -27,6 +27,7 @@ package cleanevicted
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -151,6 +152,18 @@ func TestCleanEvictedPodsLimit(t *testing.T) {
 	pods, err := client.CoreV1().Pods("test").List(context.Background(), metav1.ListOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, 50, len(pods.Items))
+}
+
+func TestCleanEvictedPodsInvalidNamespace(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	err := cleanEvictedPods(context.Background(), client, "Invalid_Namespace")
+
+	if assert.Error(t, err) {
+		assert.True(t, strings.HasPrefix(err.Error(), "invalid namespace"))
+	}
+
+	assert.Empty(t, client.Actions())
 }
 
 // TestValidateNamespace tests namespace validation.


### PR DESCRIPTION
## Summary
- add a unit test that exercises cleanEvictedPods with an invalid namespace
- assert the error prefix and absence of delete actions on the fake client

## Testing
- make vet
- make test
- make lint
- make vulcheck *(fails: package requires Go 1.24 while project uses Go 1.23)*
- make seccheck

------
https://chatgpt.com/codex/tasks/task_e_68d661f352ac832a87deefd6755c3a42