### PR TITLE
refactor: allow injecting clientset in restart deploy

### DIFF
--- a/internal/cmd/restart-deploy/restart-deploy.go
+++ b/internal/cmd/restart-deploy/restart-deploy.go
@@ -38,6 +38,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+var newClientset = func(opts *client.Options) (kubernetes.Interface, error) {
+	return client.NewClientset(opts)
+}
+
 // NewCommand returns a new Cobra command for re-balancing pods.
 func NewCommand() *cobra.Command {
 	opts := &options.Options{}
@@ -66,7 +70,7 @@ func NewCommand() *cobra.Command {
 
 			cmd.SilenceUsage = true
 
-			clnt, err := client.NewClientset(client.FromContext(ctx))
+			clnt, err := newClientset(client.FromContext(ctx))
 			if err != nil {
 				logger.FromContext(ctx).Error(err, "failed to create client")
 				return fmt.Errorf("failed to create client: %w", err)


### PR DESCRIPTION
## Summary
- add a clientset factory variable so the restart-deploy command can swap implementations
- exercise RunE with fake clientsets for --all, explicit targets, and error handling
- provide reusable test helpers for overriding the clientset factory

## Testing
- make vet
- make test
- make lint
- make vulcheck *(fails: package requires Go 1.24 when run under go1.23)*
- make seccheck

------
https://chatgpt.com/codex/tasks/task_e_68d674c8c1fc832ab49a7eedf6ccfd61