### PR TITLE
Add test for restart deployment missing object handling

### DIFF
--- a/internal/cmd/restart-deploy/restart-deploy_test.go
+++ b/internal/cmd/restart-deploy/restart-deploy_test.go
@@ -276,6 +276,18 @@ func TestRestartDeployment(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 
+	t.Run("restart missing deployment without get error", func(t *testing.T) {
+		missingClient := fake.NewSimpleClientset()
+		missingClient.PrependReactor("get", "deployments", func(action ktesting.Action) (bool, runtime.Object, error) {
+			var obj *v1.Deployment
+			return true, obj, nil
+		})
+
+		err := restartDeployment(testCtx, missingClient, "default", []string{"missing-deployment"})
+
+		assert.EqualError(t, err, "deployment default/missing-deployment not found")
+	})
+
 	t.Run("too many targets", func(t *testing.T) {
 		var names []string
 		for i := 0; i < 51; i++ {


### PR DESCRIPTION
## Summary
- add a subtest to TestRestartDeployment that simulates a missing object without a client error
- verify restartDeployment returns the expected not found error when the fake client get reactor yields no object

## Testing
- make vet
- make test
- make lint
- make vulcheck *(fails: govulncheck requires Go 1.24 while the module builds with Go 1.23)*
- make seccheck


------
https://chatgpt.com/codex/tasks/task_e_68d67f5d8ab4832aac7f74c61bc1ee3d