### PR TITLE
Add test for delete-oldest minPods safety guard

### DIFF
--- a/internal/cmd/delete-oldest/delete-oldest_test.go
+++ b/internal/cmd/delete-oldest/delete-oldest_test.go
@@ -258,6 +258,31 @@ func TestNewCommand_EarlyExitWithoutPrefix(t *testing.T) {
 	}
 }
 
+func TestNewCommand_MinPodsTooHigh(t *testing.T) {
+	cmd := NewCommand()
+	if cmd == nil {
+		t.Fatalf("expected command, but got nil")
+	}
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--namespace", "test-ns", "--prefix", "test", "--minPods", "1001"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error, but got nil")
+	}
+
+	if !strings.Contains(err.Error(), "minPods value too high for safety") {
+		t.Fatalf("expected minPods safety error, but got %v", err)
+	}
+
+	if cmd.SilenceUsage {
+		t.Fatalf("expected SilenceUsage to remain false when guard triggers")
+	}
+}
+
 func TestValidatePodPrefix(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary
- add a unit test that verifies the delete-oldest command aborts when minPods exceeds the safety limit

## Testing
- make vet
- make test
- make lint
- make vulcheck (fails: repository requires Go 1.24, current toolchain go1.23)
- make seccheck

------
https://chatgpt.com/codex/tasks/task_e_68d691081758832aba8681e76c5426b1