### PR TITLE
Add test coverage for missing default kubeconfig scenario

### DIFF
--- a/pkg/kube/client/clientutils_test.go
+++ b/pkg/kube/client/clientutils_test.go
@@ -64,6 +64,16 @@ func TestGetKubeconfig(t *testing.T) {
 			expectedSource: kubeconfigSourceDefault,
 		},
 		{
+			name: "HOME path without kubeconfig",
+			setup: func(t *testing.T) string {
+				homeDir := t.TempDir()
+				t.Setenv("HOME", homeDir)
+				t.Setenv("KUBECONFIG", "")
+				return ""
+			},
+			expectedSource: kubeconfigSourceNone,
+		},
+		{
 			name: "KUBECONFIG set",
 			setup: func(t *testing.T) string {
 				t.Setenv("HOME", "")


### PR DESCRIPTION
## Summary
- add a regression test ensuring Options.GetConfigFilePath handles a HOME directory without a kubeconfig file

## Testing
- make vet
- make test
- make lint
- make vulcheck
- make seccheck
- go test ./pkg/kube/client


------
https://chatgpt.com/codex/tasks/task_e_68d95537f1a4832a947e248b54be6c5b