### PR TITLE
Add validation test for kubeconfig directory path

### DIFF
--- a/pkg/kube/client/clientutils_test.go
+++ b/pkg/kube/client/clientutils_test.go
@@ -175,16 +175,15 @@ func TestGetKubeconfig(t *testing.T) {
 
 func TestGetKubeconfigValidationError(t *testing.T) {
 	dir := t.TempDir()
-	nonRegularPath := filepath.Join(dir, "nested")
-	if err := os.MkdirAll(nonRegularPath, 0o755); err != nil {
-		t.Fatalf("failed to create non-regular entry: %v", err)
-	}
 
-	opts := &Options{configFilePath: nonRegularPath}
+	opts := &Options{configFilePath: dir}
 
-	_, source, err := opts.GetConfigFilePath()
+	resolved, source, err := opts.GetConfigFilePath()
 	if err == nil {
 		t.Fatalf("expected validation error, got nil")
+	}
+	if resolved != "" {
+		t.Fatalf("expected empty resolved path, got %v", resolved)
 	}
 	if source != kubeconfigSourceFlag {
 		t.Fatalf("expected source kubeconfigSourceFlag, got %v", source)


### PR DESCRIPTION
## Summary
- ensure the kubeconfig validation test uses a temporary directory path
- verify the resolved path is empty and the error reports both the flag source and regular-file requirement

## Testing
- go test ./pkg/kube/client
- make vet
- make test
- make lint
- make vulcheck
- make seccheck

------
https://chatgpt.com/codex/tasks/task_e_68da2ebb0fa8832a9d314e78011440f6