### PR TITLE
Add test for missing default kubeconfig resolution

### DIFF
--- a/pkg/kube/client/clientutils_test.go
+++ b/pkg/kube/client/clientutils_test.go
@@ -171,6 +171,34 @@ func TestGetKubeconfig(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("NoDefaultKubeconfigWhenMissing", func(t *testing.T) {
+		homeDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		t.Setenv("KUBECONFIG", "")
+
+		opts := &Options{}
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+		defer func() {
+			flag.CommandLine = backup
+		}()
+
+		opts.BindFlags(flag.CommandLine)
+		if err := flag.CommandLine.Parse([]string{}); err != nil {
+			t.Fatalf("failed to parse flags: %v", err)
+		}
+
+		path, source, err := opts.GetConfigFilePath()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if path != "" {
+			t.Fatalf("expected empty path, got %s", path)
+		}
+		if source != kubeconfigSourceNone {
+			t.Fatalf("expected source kubeconfigSourceNone, got %v", source)
+		}
+	})
 }
 
 func TestGetKubeconfigValidationError(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a focused subtest covering the absence of a default kubeconfig when HOME lacks a config file

## Testing
- go test ./pkg/kube/client

------
https://chatgpt.com/codex/tasks/task_e_68da2ff45e3c832ab750943571a42d64