### PR TITLE
Add hasPathPrefix unit tests

### DIFF
--- a/pkg/kube/client/clientutils_test.go
+++ b/pkg/kube/client/clientutils_test.go
@@ -297,6 +297,51 @@ func TestGetKubeconfigDeniedPrefixViaSymlink(t *testing.T) {
 	}
 }
 
+func TestHasPathPrefix(t *testing.T) {
+	tempDir := t.TempDir()
+	cases := []struct {
+		name     string
+		path     string
+		prefix   string
+		expected bool
+	}{
+		{
+			name:     "empty prefix returns false",
+			path:     filepath.Join(tempDir, "config"),
+			prefix:   "",
+			expected: false,
+		},
+		{
+			name:     "identical path returns true",
+			path:     filepath.Join(tempDir, "config"),
+			prefix:   filepath.Join(tempDir, "config"),
+			expected: true,
+		},
+		{
+			name:     "prefix without trailing slash matches",
+			path:     filepath.Join(tempDir, "allowed", "nested", "config"),
+			prefix:   filepath.Join(tempDir, "allowed", "nested"),
+			expected: true,
+		},
+		{
+			name:     "unrelated paths return false",
+			path:     filepath.Join(tempDir, "allowed", "config"),
+			prefix:   filepath.Join(tempDir, "denied"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			result := hasPathPrefix(tc.path, tc.prefix)
+			if result != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}
+
 func TestGetKubeconfigAllowedPrefix(t *testing.T) {
 	dir := t.TempDir()
 	kubeconfigPath := filepath.Join(dir, "config")


### PR DESCRIPTION
## Summary
- add TestHasPathPrefix covering empty, identical, slashless, and unrelated path scenarios

## Testing
- go test ./pkg/kube/client > /tmp/gotest.log

------
https://chatgpt.com/codex/tasks/task_e_68da33c2b808832aa31116d129326bab