### PR TITLE
test: cover missing kubeconfig resolution

### DIFF
--- a/pkg/kube/client/clientutils_test.go
+++ b/pkg/kube/client/clientutils_test.go
@@ -171,6 +171,33 @@ func TestGetKubeconfig(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("HomeWithoutKubeconfigReturnsNone", func(t *testing.T) {
+		homeDir := t.TempDir()
+		t.Setenv("HOME", homeDir)
+		t.Setenv("KUBECONFIG", "")
+
+		opts := &Options{}
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+		defer func() {
+			flag.CommandLine = backup
+		}()
+		opts.BindFlags(flag.CommandLine)
+		if err := flag.CommandLine.Parse([]string{}); err != nil {
+			t.Fatalf("failed to parse flags: %v", err)
+		}
+
+		path, source, err := opts.GetConfigFilePath()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if path != "" {
+			t.Fatalf("expected empty path, got %q", path)
+		}
+		if source != kubeconfigSourceNone {
+			t.Fatalf("expected kubeconfigSourceNone, got %v", source)
+		}
+	})
 }
 
 func TestGetKubeconfigValidationError(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a dedicated subtest to verify that GetConfigFilePath returns no path when HOME lacks a kubeconfig

## Testing
- make vet
- make test
- make lint
- make vulcheck
- make seccheck

------
https://chatgpt.com/codex/tasks/task_e_68da33f61dd8832a885502a8d7e0d2df