### PR TITLE
Add tests for SetPathPrefixAllowList slice handling

### DIFF
--- a/pkg/kube/client/clientutils_test.go
+++ b/pkg/kube/client/clientutils_test.go
@@ -355,6 +355,35 @@ func TestSetPathPrefixAllowListEmptyEntryIgnored(t *testing.T) {
 	}
 }
 
+func TestSetPathPrefixAllowListCopiesInput(t *testing.T) {
+	opts := &Options{}
+	dir := t.TempDir()
+	prefixes := []string{dir}
+
+	opts.SetPathPrefixAllowList(prefixes)
+
+	mutatedValue := filepath.Join(dir, "mutated")
+	prefixes[0] = mutatedValue
+
+	if len(opts.allowedPathPrefixes) != len(prefixes) {
+		t.Fatalf("expected allowed prefixes length %d, got %d", len(prefixes), len(opts.allowedPathPrefixes))
+	}
+
+	if opts.allowedPathPrefixes[0] != dir {
+		t.Fatalf("expected stored prefix %q to remain unchanged, got %q", dir, opts.allowedPathPrefixes[0])
+	}
+}
+
+func TestSetPathPrefixAllowListNilInput(t *testing.T) {
+	opts := &Options{}
+
+	opts.SetPathPrefixAllowList(nil)
+
+	if opts.allowedPathPrefixes != nil {
+		t.Fatalf("expected nil allowedPathPrefixes when input is nil")
+	}
+}
+
 func TestFromContext(t *testing.T) {
 	// Test when context contains Options value
 	expectedOptions := &Options{} // Replace with the actual initialization of Options struct


### PR DESCRIPTION
## Summary
- add coverage ensuring SetPathPrefixAllowList copies the provided slice before storing it
- verify that a nil input leaves the stored allow list slice nil

## Testing
- make vet
- make test
- make lint
- make vulcheck
- make seccheck
- go test ./pkg/kube/client

------
https://chatgpt.com/codex/tasks/task_e_68da33c0fd90832aa334d2fa6459ecda