### PR TITLE
Add tests for kubeconfig flag bindings

### DIFF
--- a/pkg/kube/client/clientutils_test.go
+++ b/pkg/kube/client/clientutils_test.go
@@ -37,10 +37,7 @@ import (
 
 func TestBindFlagsAndPFlags(t *testing.T) {
 	t.Run("FlagSet", func(t *testing.T) {
-		tmpFile := filepath.Join(t.TempDir(), "config")
-		if err := os.WriteFile(tmpFile, []byte("apiVersion: v1\n"), 0o600); err != nil {
-			t.Fatalf("failed to write temp kubeconfig: %v", err)
-		}
+		tmpFile := createTempKubeconfig(t)
 
 		opts := &Options{}
 		fs := flag.NewFlagSet("test", flag.ContinueOnError)
@@ -56,10 +53,7 @@ func TestBindFlagsAndPFlags(t *testing.T) {
 	})
 
 	t.Run("PFlagSet", func(t *testing.T) {
-		tmpFile := filepath.Join(t.TempDir(), "config")
-		if err := os.WriteFile(tmpFile, []byte("apiVersion: v1\n"), 0o600); err != nil {
-			t.Fatalf("failed to write temp kubeconfig: %v", err)
-		}
+		tmpFile := createTempKubeconfig(t)
 
 		opts := &Options{}
 		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)


### PR DESCRIPTION
## Summary
- ensure the kubeconfig flag binding test covers stdlib and pflag sets using the shared kubeconfig helper

## Testing
- go test ./pkg/kube/client
- make vet
- make test
- make lint
- make vulcheck
- make seccheck

------
https://chatgpt.com/codex/tasks/task_e_68da33cc67e8832aaffcd182cf34f1e6