### PR TITLE
Add test coverage for nil StatefulSet fetch

### DIFF
--- a/internal/cmd/restart-sts/restart-sts_test.go
+++ b/internal/cmd/restart-sts/restart-sts_test.go
@@ -148,6 +148,23 @@ func TestRestartStatefulSet(t *testing.T) {
 		assert.True(t, patchCalled, "Expected patch to be called")
 	})
 
+	t.Run("get returns nil object", func(t *testing.T) {
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sts",
+				Namespace: "default",
+			},
+		}
+		client := fake.NewSimpleClientset(sts)
+		client.PrependReactor("get", "statefulsets", func(action ktesting.Action) (bool, runtime.Object, error) {
+			var nilStatefulSet *appsv1.StatefulSet
+			return true, nilStatefulSet, nil
+		})
+
+		err := restartStatefulSet(testCtx, client, "default", []string{"test-sts"})
+		assert.EqualError(t, err, "statefulset default/test-sts not found")
+	})
+
 	t.Run("too many targets", func(t *testing.T) {
 		var names []string
 		for i := 0; i < 51; i++ {


### PR DESCRIPTION
## Summary
- add a restart-sts subtest that simulates a nil StatefulSet result with no error
- ensure the controller returns the expected not-found error when the get reactor yields nil

## Testing
- make vet
- make test
- make lint
- make vulcheck
- make seccheck

------
https://chatgpt.com/codex/tasks/task_e_68da9a11a184832aa1fd435f20c41e81