### PR TITLE
Add test coverage for clientset errors in rebalance command

### DIFF
--- a/internal/cmd/rebalance-pods/rebalance-pods_test.go
+++ b/internal/cmd/rebalance-pods/rebalance-pods_test.go
@@ -231,6 +231,18 @@ func TestNewCommand(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestNewCommand_ClientsetError(t *testing.T) {
+	t.Setenv("KUBECONFIG", "/non-existent/path")
+
+	cmd := NewCommand()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "failed to create client")
+	}
+}
+
 func TestValidateNamespace(t *testing.T) {
 	assert.Error(t, validation.ValidateNamespace(""))
 	assert.Error(t, validation.ValidateNamespace("Invalid*"))


### PR DESCRIPTION
## Summary
- add a unit test to ensure rebalance-pods surfaces client creation errors

## Testing
- make vet
- make test
- make lint
- make vulcheck
- make seccheck

------
https://chatgpt.com/codex/tasks/task_e_68db5a502f54832aa2440418de1b57f4