### PR TITLE
Add clientset error coverage for rebalance pods command

### DIFF
--- a/internal/cmd/rebalance-pods/rebalance-pods_test.go
+++ b/internal/cmd/rebalance-pods/rebalance-pods_test.go
@@ -27,6 +27,7 @@ package rebalancepods
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/norseto/k8s-watchdogs/internal/pkg/validation"
@@ -232,7 +233,8 @@ func TestNewCommand(t *testing.T) {
 }
 
 func TestNewCommand_ClientsetError(t *testing.T) {
-	t.Setenv("KUBECONFIG", "/non-existent/path")
+	missingKubeconfig := filepath.Join(t.TempDir(), "non-existent", "config")
+	t.Setenv("KUBECONFIG", missingKubeconfig)
 
 	cmd := NewCommand()
 	cmd.SetArgs([]string{})


### PR DESCRIPTION
## Summary
- ensure the rebalance pods command surfaces clientset creation failures by simulating a missing kubeconfig

## Testing
- make vet
- make test
- make lint
- make vulcheck
- make seccheck

------
https://chatgpt.com/codex/tasks/task_e_68db82b15cc8832a88f402270a556d85